### PR TITLE
Display thumbnails below slide section

### DIFF
--- a/resources/css/work.css
+++ b/resources/css/work.css
@@ -76,3 +76,103 @@
     font-size: 50px;
     color: #888;
 }
+
+/* サムネイル表示のスタイル */
+.thumbnails-container {
+    width: 80%;
+    margin: 40px auto 0 auto;
+    display: flex;
+    justify-content: center;
+    gap: 15px;
+    flex-wrap: wrap;
+    padding: 20px 0;
+}
+
+.thumbnail {
+    width: 120px;
+    height: 90px;
+    cursor: pointer;
+    border: 3px solid transparent;
+    border-radius: 8px;
+    overflow: hidden;
+    transition: all 0.3s ease;
+    background-color: #fff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.thumbnail:hover {
+    border-color: #007bff;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.thumbnail.active {
+    border-color: #007bff;
+    box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
+}
+
+.thumbnail-img {
+    width: 100%;
+    height: 70px;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+.thumbnail-title {
+    padding: 4px 8px;
+    font-size: 10px;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: #333;
+    background-color: #fff;
+    height: 20px;
+    line-height: 12px;
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 767px) {
+    .thumbnails-container {
+        width: 95%;
+        gap: 10px;
+    }
+    
+    .thumbnail {
+        width: 80px;
+        height: 60px;
+    }
+    
+    .thumbnail-img {
+        height: 45px;
+    }
+    
+    .thumbnail-title {
+        font-size: 8px;
+        padding: 2px 4px;
+        height: 15px;
+        line-height: 11px;
+    }
+}
+
+@media (max-width: 480px) {
+    .thumbnails-container {
+        gap: 8px;
+    }
+    
+    .thumbnail {
+        width: 70px;
+        height: 50px;
+    }
+    
+    .thumbnail-img {
+        height: 35px;
+    }
+    
+    .thumbnail-title {
+        font-size: 7px;
+        height: 15px;
+        line-height: 8px;
+    }
+}

--- a/resources/ts/components/Work.tsx
+++ b/resources/ts/components/Work.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { Box, Card, CircularProgress } from "@mui/material";
 import Slider from "react-slick";
 import axios from "axios";
@@ -8,6 +8,9 @@ import "../../css/work.css";
 import { Work } from "../@types";
 
 const Works = () => {
+    const sliderRef = useRef<Slider>(null);
+    const [currentSlide, setCurrentSlide] = React.useState(0);
+
     useEffect(() => {
         getData();
     }, []);
@@ -29,6 +32,15 @@ const Works = () => {
             });
     };
 
+    const handleThumbnailClick = (index: number) => {
+        sliderRef.current?.slickGoTo(index);
+        setCurrentSlide(index);
+    };
+
+    const handleSlideChange = (index: number) => {
+        setCurrentSlide(index);
+    };
+
     return (
         <>
             {loading ? (
@@ -46,6 +58,7 @@ const Works = () => {
                 <div id="work">
                     <h2>Work</h2>
                     <Slider
+                        ref={sliderRef}
                         dots
                         lazyLoad="ondemand"
                         infinite
@@ -55,8 +68,9 @@ const Works = () => {
                         autoplay
                         autoplaySpeed={2000}
                         centerMode
+                        beforeChange={(current: number, next: number) => handleSlideChange(next)}
                     >
-                        {post.map((postt, index) => {
+                        {post.map((postt: Work, index: number) => {
                             return (
                                 <div className="slide_cmp" key={index}>
                                     <Card
@@ -99,6 +113,25 @@ const Works = () => {
                             );
                         })}
                     </Slider>
+                    
+                    {/* サムネイル表示部分 */}
+                    <div className="thumbnails-container">
+                        {post.map((postt, index) => (
+                            <div
+                                key={index}
+                                className={`thumbnail ${currentSlide === index ? 'active' : ''}`}
+                                onClick={() => handleThumbnailClick(index)}
+                            >
+                                <div
+                                    className="thumbnail-img"
+                                    style={{
+                                        backgroundImage: `url('/storage/image/${postt.path}')`,
+                                    }}
+                                ></div>
+                                <div className="thumbnail-title">{postt.name}</div>
+                            </div>
+                        ))}
+                    </div>
                 </div>
             )}
         </>


### PR DESCRIPTION
Thumbnails were added below the slider in the `Work` component to allow direct navigation and provide visual context.

*   In `resources/ts/components/Work.tsx`:
    *   A `useRef` was introduced to programmatically control the `Slider` component.
    *   `currentSlide` state was added to track the active slide for thumbnail highlighting.
    *   `handleThumbnailClick` function was implemented to navigate the slider to the clicked thumbnail's index using `slickGoTo`.
    *   `handleSlideChange` was added to update `currentSlide` via the `beforeChange` prop of the `Slider`.
    *   A new `div` with class `thumbnails-container` was rendered below the `Slider`, mapping over `post` data to display individual thumbnails.
    *   Thumbnails dynamically apply an `active` class based on `currentSlide` and trigger `handleThumbnailClick` on click.

*   In `resources/css/work.css`:
    *   New CSS rules were added for `.thumbnails-container`, `.thumbnail`, `.thumbnail-img`, and `.thumbnail-title` to style the thumbnail layout, appearance, and text.
    *   Styles for `:hover` and `.active` states were included to provide visual feedback.
    *   Media queries were added for responsive adjustments on tablet and mobile viewports.